### PR TITLE
CMakeLists.txt: add missing libraries to link

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,8 @@ message(STATUS "Found list of source files: ${SOURCES}")
 set(LIB_NAMES "")
 list(APPEND LIB_NAMES "ROOT::Core")
 list(APPEND LIB_NAMES "ROOT::Gpad")
+list(APPEND LIB_NAMES "ROOT::Gui")
+list(APPEND LIB_NAMES "ROOT::Physics")
 
 # TARGET: create shared library
 set(SHARED_LIB_TARGET ${PROJECT_NAME}-so)


### PR DESCRIPTION
Fixes a linker error (ld64 on macOS, by default, requires all symbols to be resolved at link time):
```
Undefined symbols for architecture x86_64:
  "TGFileInfo::SetMultipleSelection(bool)", referenced from:
      UiUtils::getFilePaths(bool) in UiUtils.cpp.o
  "TGFileInfo::SetIniDir(char const*)", referenced from:
      UiUtils::getFilePaths(bool) in UiUtils.cpp.o
  "TGFileInfo::~TGFileInfo()", referenced from:
      UiUtils::getFilePaths(bool) in UiUtils.cpp.o
  "TGFileDialog::TGFileDialog(TGWindow const*, TGWindow const*, EFileDialogMode, TGFileInfo*)", referenced from:
      UiUtils::getFilePaths(bool) in UiUtils.cpp.o
  "TGClient::Instance()", referenced from:
      UiUtils::showMessageBox(char const*, char const*, EMsgBoxIcon) in UiUtils.cpp.o
      UiUtils::showMessageBoxYesNo(char const*, char const*, EMsgBoxIcon) in UiUtils.cpp.o
      UiUtils::getFilePaths(bool) in UiUtils.cpp.o
  "TGMsgBox::TGMsgBox(TGWindow const*, TGWindow const*, char const*, char const*, EMsgBoxIcon, int, int*, unsigned int, int)", referenced from:
      UiUtils::showMessageBox(char const*, char const*, EMsgBoxIcon) in UiUtils.cpp.o
      UiUtils::showMessageBoxYesNo(char const*, char const*, EMsgBoxIcon) in UiUtils.cpp.o
  "TVector2::TVector2(double, double)", referenced from:
      FitUtils::getCrystalBallMean(TF1*) in FitUtils.cpp.o
      FitUtils::getCrystalBallDispersion(TF1*) in FitUtils.cpp.o
      FitUtils::evalResolution(double, double, double, double) in FitUtils.cpp.o
      FitUtils::getCrystalBallResolution(TF1*) in FitUtils.cpp.o
  "TVector2::~TVector2()", referenced from:
      FitUtils::getCrystalBallResolution(TF1*) in FitUtils.cpp.o
  "TGClient::GetRoot() const", referenced from:
      UiUtils::showMessageBox(char const*, char const*, EMsgBoxIcon) in UiUtils.cpp.o
      UiUtils::showMessageBoxYesNo(char const*, char const*, EMsgBoxIcon) in UiUtils.cpp.o
      UiUtils::getFilePaths(bool) in UiUtils.cpp.o
ld: symbol(s) not found for architecture x86_64
```